### PR TITLE
Handle fldSimple fields without runs

### DIFF
--- a/src/mailmerge/part.py
+++ b/src/mailmerge/part.py
@@ -25,6 +25,8 @@ class Part:
     def __fill_simple_fields(self):
         for fld_simple_elem in self.part.findall(".//{%(w)s}fldSimple" % NAMESPACES):
             first_run_elem = deepcopy(fld_simple_elem.find("{%(w)s}r" % NAMESPACES))
+            if first_run_elem is None:
+                continue
             if MAKE_TESTS_HAPPY:
                 first_run_elem.clear()
             merge_field_obj = self.merge_data.make_data_field(

--- a/tests/test_issue39.py
+++ b/tests/test_issue39.py
@@ -1,0 +1,35 @@
+import io
+import unittest
+import zipfile
+
+from mailmerge import MailMerge
+
+
+def make_docx(document_xml):
+    docx = io.BytesIO()
+    with zipfile.ZipFile(docx, "w") as archive:
+        archive.writestr(
+            "[Content_Types].xml",
+            """<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>""",
+        )
+        archive.writestr("word/document.xml", document_xml)
+    docx.seek(0)
+    return docx
+
+
+class Issue39Test(unittest.TestCase):
+    def test_ignores_simple_field_without_run(self):
+        document_xml = """<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p>
+      <w:fldSimple w:instr="PAGEREF _Toc1 \\h"/>
+    </w:p>
+  </w:body>
+</w:document>"""
+
+        with MailMerge(make_docx(document_xml)) as document:
+            self.assertEqual(document.get_merge_fields(), set())


### PR DESCRIPTION
## Summary
- skip `fldSimple` elements that do not contain a `w:r` run
- add a regression test for a minimal document with a run-less `fldSimple`

Fixes #39.

## Tests
- `uv run --python $(command -v python3) python -m unittest tests.test_issue39 tests.test_empty_field tests.test_issue8`
- `uv run --python $(command -v python3) --with ruff ruff check src/mailmerge/part.py tests/test_issue39.py`
- `uv run --python $(command -v python3) --with ruff ruff format --check src/mailmerge/part.py tests/test_issue39.py`
- `git diff --check`

Also ran `uv run --python $(command -v python3) python -m unittest discover`; it still fails the pre-existing locale-sensitive `tests.test_formatting.FormattingTest.test_date` assertion where `%b` returns `März` instead of the expected `Mär`.

AI assistance was used under my direction.